### PR TITLE
Fixed the issue where the countdown status was incorrect when the event had not yet started in the timeline

### DIFF
--- a/src/routes/timeline/Detail.svelte
+++ b/src/routes/timeline/Detail.svelte
@@ -61,8 +61,10 @@
 	<p class="mt-4 w-fit rounded-md border border-white/10 bg-purple-300/5 px-2 py-1 text-white/90">
 		{#if ended}
 			Finished
-		{:else}
+		{:else if started}
 			Ending in {duration}
+		{:else}
+			Starting in {duration}
 		{/if}
 	</p>
 </div>


### PR DESCRIPTION
The event in example:
![image](https://github.com/MadeBaruna/pom-moe/assets/1592579/418effc3-af3b-4846-bf25-53798d2c874b)

Before:
![image](https://github.com/MadeBaruna/pom-moe/assets/1592579/583a8e98-216f-4a6a-91e7-c0e49bd1d108)

After:
![image](https://github.com/MadeBaruna/pom-moe/assets/1592579/8b598b7e-895c-46ad-9cbb-f35d1ed151fc)
